### PR TITLE
Hubbard operators: support additional symmetries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MPSKitModels"
 uuid = "ca635005-6f8c-4cd1-b51d-8491250ef2ab"
 authors = ["Maarten Van Damme", "Lukas Devos", "Gertian Roose", "Klaas Gunst"]
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/operators/hubbardoperators.jl
+++ b/src/operators/hubbardoperators.jl
@@ -77,13 +77,25 @@ function e_plusmin_up(T, ::Type{Trivial}, ::Type{Trivial})
     return t
 end
 function e_plusmin_up(T, ::Type{Trivial}, ::Type{U1Irrep})
-    return error("Not implemented")
+    t = two_site_operator(T, Trivial, U1Irrep)
+    I = sectortype(t)
+    t[(I(1, 1 // 2), I(0, 0), dual(I(0, 0)), dual(I(1, 1 // 2)))][1, 1, 1, 1] = 1
+    t[(I(1, 1 // 2), I(1, -1 // 2), dual(I(0, 0)), dual(I(0, 0)))][1, 1, 1, 2] = 1
+    t[(I(0, 0), I(0, 0), dual(I(1, -1 // 2)), dual(I(1, 1 // 2)))][2, 1, 1, 1] = -1
+    t[(I(0, 0), I(1, -1 // 2), dual(I(1, -1 // 2)), dual(I(0, 0)))][2, 1, 1, 2] = -1
+    return t
 end
 function e_plusmin_up(T, ::Type{Trivial}, ::Type{SU2Irrep})
     return error("Not implemented")
 end
 function e_plusmin_up(T, ::Type{U1Irrep}, ::Type{Trivial})
-    return error("Not implemented")
+    t = two_site_operator(T, U1Irrep, Trivial)
+    I = sectortype(t)
+    t[(I(1, 1), I(0, 0), dual(I(0, 0)), dual(I(1, 1)))][1, 1, 1, 1] = 1
+    t[(I(1, 1), I(1, 1), dual(I(0, 0)), dual(I(0, 2)))][1, 2, 1, 1] = 1
+    t[(I(0, 2), I(0, 0), dual(I(1, 1)), dual(I(1, 1)))][1, 1, 2, 1] = -1
+    t[(I(0, 2), I(1, 1), dual(I(1, 1)), dual(I(0, 2)))][1, 2, 2, 1] = -1
+    return t
 end
 function e_plusmin_up(T, ::Type{U1Irrep}, ::Type{U1Irrep})
     t = two_site_operator(T, U1Irrep, U1Irrep)
@@ -124,13 +136,25 @@ function e_plusmin_down(T, ::Type{Trivial}, ::Type{Trivial})
     return t
 end
 function e_plusmin_down(T, ::Type{Trivial}, ::Type{U1Irrep})
-    return error("Not implemented")
+    t = two_site_operator(T, Trivial, U1Irrep)
+    I = sectortype(t)
+    t[(I(1, -1 // 2), I(0, 0), dual(I(0, 0)), dual(I(1, -1 // 2)))][1, 1, 1, 1] = 1
+    t[(I(1, -1 // 2), I(1, 1 // 2), dual(I(0, 0)), dual(I(0, 0)))][1, 1, 1, 2] = -1
+    t[(I(0, 0), I(0, 0), dual(I(1, 1 // 2)), dual(I(1, -1 // 2)))][2, 1, 1, 1] = 1
+    t[(I(0, 0), I(1, 1 // 2), dual(I(1, 1 // 2)), dual(I(0, 0)))][2, 1, 1, 2] = -1
+    return t
 end
 function e_plusmin_down(T, ::Type{Trivial}, ::Type{SU2Irrep})
     return error("Not implemented")
 end
 function e_plusmin_down(T, ::Type{U1Irrep}, ::Type{Trivial})
-    return error("Not implemented")
+    t = two_site_operator(T, U1Irrep, Trivial)
+    I = sectortype(t)
+    t[(I(1, 1), I(0, 0), dual(I(0, 0)), dual(I(1, 1)))][2, 1, 1, 2] = 1
+    t[(I(1, 1), I(1, 1), dual(I(0, 0)), dual(I(0, 2)))][2, 1, 1, 1] = -1
+    t[(I(0, 2), I(0, 0), dual(I(1, 1)), dual(I(1, 1)))][1, 1, 1, 2] = 1
+    t[(I(0, 2), I(1, 1), dual(I(1, 1)), dual(I(0, 2)))][1, 1, 1, 1] = -1
+    return t
 end
 function e_plusmin_down(T, ::Type{U1Irrep}, ::Type{U1Irrep})
     t = two_site_operator(T, U1Irrep, U1Irrep)
@@ -192,6 +216,23 @@ function e_plusmin(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:S
     return e_plusmin_up(T, particle_symmetry, spin_symmetry) +
            e_plusmin_down(T, particle_symmetry, spin_symmetry)
 end
+function e_plusmin(T, ::Type{Trivial}, ::Type{SU2Irrep})
+    t = two_site_operator(T, Trivial, SU2Irrep)
+    I = sectortype(t)
+    f1 = only(fusiontrees((I(0, 0), I(1, 1 // 2)), I(1, 1 // 2)))
+    f2 = only(fusiontrees((I(1, 1 // 2), I(0, 0)), I(1, 1 // 2)))
+    t[f1, f2][1, 1, 1, 1] = 1
+    f3 = only(fusiontrees((I(1, 1 // 2), I(0, 0)), I(1, 1 // 2)))
+    f4 = only(fusiontrees((I(0, 0), I(1, 1 // 2)), I(1, 1 // 2)))
+    t[f3, f4][1, 2, 2, 1] = -1
+    f5 = only(fusiontrees((I(0, 0), I(0, 0)), I(0, 0)))
+    f6 = only(fusiontrees((I(1, 1 // 2), I(1, 1 // 2)), I(0, 0)))
+    t[f5, f6][1, 2, 1, 1] = sqrt(2)
+    f7 = only(fusiontrees((I(1, 1 // 2), I(1, 1 // 2)), I(0, 0)))
+    f8 = only(fusiontrees((I(0, 0), I(0, 0)), I(0, 0)))
+    t[f7, f8][1, 1, 2, 1] = sqrt(2)
+    return t
+end
 function e_plusmin(T, ::Type{U1Irrep}, ::Type{SU2Irrep})
     t = two_site_operator(T, U1Irrep, SU2Irrep)
     I = sectortype(t)
@@ -237,13 +278,21 @@ function e_number_up(T::Type{<:Number}, ::Type{Trivial}=Trivial, ::Type{Trivial}
     return t
 end
 function e_number_up(T, ::Type{Trivial}, ::Type{U1Irrep})
-    return error("Not implemented")
+    t = single_site_operator(T, Trivial, U1Irrep)
+    I = sectortype(t)
+    t[(I(1, 1 // 2), dual(I(1, 1 // 2)))][1, 1] = 1
+    t[(I(0, 0), dual(I(0, 0)))][2, 2] = 1
+    return t
 end
 function e_number_up(T, ::Type{Trivial}, ::Type{SU2Irrep})
     throw(ArgumentError("`e_number_up` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 function e_number_up(T, ::Type{U1Irrep}, ::Type{Trivial})
-    return error("Not implemented")
+    t = single_site_operator(T, U1Irrep, Trivial)
+    I = sectortype(t)
+    block(t, I(1, 1))[1, 1] = 1
+    block(t, I(0, 2))[1, 1] = 1
+    return t
 end
 function e_number_up(T, ::Type{U1Irrep}, ::Type{U1Irrep})
     t = single_site_operator(T, U1Irrep, U1Irrep)
@@ -280,13 +329,21 @@ function e_number_down(T::Type{<:Number}, ::Type{Trivial}=Trivial, ::Type{Trivia
     return t
 end
 function e_number_down(T, ::Type{Trivial}, ::Type{U1Irrep})
-    return error("Not implemented")
+    t = single_site_operator(T, Trivial, U1Irrep)
+    I = sectortype(t)
+    t[(I(1, -1 // 2), dual(I(1, -1 // 2)))][1, 1] = 1
+    t[(I(0, 0), I(0, 0))][2, 2] = 1
+    return t
 end
 function e_number_down(T, ::Type{Trivial}, ::Type{SU2Irrep})
     throw(ArgumentError("`e_number_down` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 function e_number_down(T, ::Type{U1Irrep}, ::Type{Trivial})
-    return error("Not implemented")
+    t = single_site_operator(T, U1Irrep, Trivial)
+    I = sectortype(t)
+    block(t, I(1, 1))[2, 2] = 1 # expected to be [1,2]
+    block(t, I(0, 2))[1, 1] = 1
+    return t
 end
 function e_number_down(T, ::Type{U1Irrep}, ::Type{U1Irrep})
     t = single_site_operator(T, U1Irrep, U1Irrep)
@@ -319,6 +376,13 @@ function e_number(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Se
     return e_number_up(T, particle_symmetry, spin_symmetry) +
            e_number_down(T, particle_symmetry, spin_symmetry)
 end
+function e_number(T, ::Type{Trivial}, ::Type{SU2Irrep})
+    t = single_site_operator(T, Trivial, SU2Irrep)
+    I = sectortype(t)
+    block(t, I(1, 1 // 2))[1, 1] = 1
+    block(t, I(0, 0))[2, 2] = 2
+    return t
+end
 function e_number(T, ::Type{U1Irrep}, ::Type{SU2Irrep})
     t = single_site_operator(T, U1Irrep, SU2Irrep)
     I = sectortype(t)
@@ -338,6 +402,12 @@ function e_number_updown(T, particle_symmetry::Type{<:Sector},
                          spin_symmetry::Type{<:Sector})
     return e_number_up(T, particle_symmetry, spin_symmetry) *
            e_number_down(T, particle_symmetry, spin_symmetry)
+end
+function e_number_updown(T, ::Type{Trivial}, ::Type{SU2Irrep})
+    t = single_site_operator(T, Trivial, SU2Irrep)
+    I = sectortype(t)
+    block(t, I(0, 0))[2, 2] = 1
+    return t
 end
 function e_number_updown(T, ::Type{U1Irrep}, ::Type{SU2Irrep})
     t = single_site_operator(T, U1Irrep, SU2Irrep)

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -3,7 +3,9 @@ using TensorKit
 using MPSKitModels.HubbardOperators
 using LinearAlgebra: eigvals
 
-implemented_symmetries = [(Trivial, Trivial), (U1Irrep, U1Irrep), (U1Irrep, SU2Irrep)]
+implemented_symmetries = [(Trivial, Trivial), (Trivial, U1Irrep), (Trivial, SU2Irrep),
+                          (U1Irrep, Trivial), (U1Irrep, U1Irrep), (U1Irrep, SU2Irrep)]
+
 @testset "basic properties" begin
     for particle_symmetry in (Trivial, U1Irrep, SU2Irrep),
         spin_symmetry in (Trivial, U1Irrep, SU2Irrep)


### PR DESCRIPTION
Implements all symmetries for the Hubbard operators apart from the charge SU(2) symmetry. This is a copy from the work done in TensorKitTensors.jl