### PR TITLE
Relax `deduce_pspaces`

### DIFF
--- a/src/operators/mpoham.jl
+++ b/src/operators/mpoham.jl
@@ -83,9 +83,18 @@ function deduce_pspaces(opps::SumOfLocalOperators)
     end
 
     non_deduced = map(ismissing, pspaces)
-    any(non_deduced) &&
-        error("cannot automatically deduce physical spaces at $(findall(non_deduced))")
 
+    if any(non_deduced) # Some spaces were not defined / not able to be deduced
+        if allequal(filter(!ismissing, pspaces)) # all non-missing spaces are equal
+            # fill in the missing spaces with the unique non-missing space
+            uniquespace = first(filter(!ismissing, pspaces))
+            for i in eachindex(pspaces)
+                pspaces[i] = uniquespace
+            end
+        else # Not all non-missing spaces are equal
+            error("cannot automatically deduce physical spaces at $(findall(non_deduced))")
+        end
+    end
     return collect(S, pspaces)
 end
 

--- a/src/operators/mpoham.jl
+++ b/src/operators/mpoham.jl
@@ -82,17 +82,17 @@ function deduce_pspaces(opps::SumOfLocalOperators)
         end
     end
 
-    non_deduced = map(ismissing, pspaces)
+    not_missing = filter(!ismissing, pspaces)
 
-    if any(non_deduced) # Some spaces were not defined / not able to be deduced
-        if allequal(filter(!ismissing, pspaces)) # all non-missing spaces are equal
+    if length(not_missing) != length(pspaces) # Some spaces were not defined / not able to be deduced
+        if allequal(not_missing) # all non-missing spaces are equal
             # fill in the missing spaces with the unique non-missing space
-            uniquespace = first(filter(!ismissing, pspaces))
+            uniquespace = first(not_missing)
             for i in eachindex(pspaces)
                 pspaces[i] = uniquespace
             end
         else # Not all non-missing spaces are equal
-            error("cannot automatically deduce physical spaces at $(findall(non_deduced))")
+            error("cannot automatically deduce physical spaces at $(findall(map(ismissing, pspaces)))")
         end
     end
     return collect(S, pspaces)

--- a/test/mpoham.jl
+++ b/test/mpoham.jl
@@ -1,4 +1,4 @@
-using MPSKitModels
+using MPSKitModels, MPSKit, TensorKit
 
 lattice = InfiniteChain(1)
 H1 = @mpoham begin
@@ -19,4 +19,14 @@ end
     lattice = InfiniteCylinder(5)
     H = @mpoham sum(ZZ{i,j} for (i, j) in nearest_neighbours(lattice))
     @test length(H) == length(lattice)
+end
+
+@testset "deduce_pspaces" begin
+    # Not fully defining the pspaces should still work
+    lattice = FiniteChain(5)
+    H = @mpoham S_zz(){lattice[2],lattice[3]}
+
+    @test unique(MPSKit.physicalspace(H))[1] == ComplexSpace(2)
+
+    @test_throws Exception @mpoham σˣ(){lattice[1]} + σˣ(; spin=3 // 2){lattice[2]}
 end


### PR DESCRIPTION
I relaxed `deduce_pspaces` to make the user able to define an operator on a lattice without having to fully specify an operator on each site using @mpoham.
The behaviour now is the following:
- If you supply an operator on every site no behaviour is changed since before.
- If you only supply `@mpoham` with operators acting upon some of the lattice sites it will now either:
    1. Assume all sites have the same local Hilbert space if all the supplied operators have the same local Hilbert space.
    2. Error if the supplied operators have a different local Hilbert space.

 