### PR TITLE
Update MPSKitModels and fix charge shift convention

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MPSKitModels"
 uuid = "ca635005-6f8c-4cd1-b51d-8491250ef2ab"
 authors = ["Maarten Van Damme", "Lukas Devos", "Gertian Roose", "Klaas Gunst"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -13,7 +13,7 @@ TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 
 [compat]
-MPSKit = "0.12"
+MPSKit = "0.13"
 MacroTools = "0.5"
 PrecompileTools = "1"
 QuadGK = "2.11.1"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 
 [compat]
-MPSKit = "0.13"
+MPSKit = "0.13.1"
 MacroTools = "0.5"
 PrecompileTools = "1"
 QuadGK = "2.11.1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+MPSKit = "bb1c41ca-d63c-52ed-829e-0820dda26502"
+MPSKitModels = "ca635005-6f8c-4cd1-b51d-8491250ef2ab"
 
 [compat]
-Documenter = "0.25 - 0.30"
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,12 @@
+# if examples is not the current active environment, switch to it
+if Base.active_project() != joinpath(@__DIR__, "Project.toml")
+    using Pkg
+    Pkg.activate(@__DIR__)
+    Pkg.develop(PackageSpec(; path=(@__DIR__) * "/../"))
+    Pkg.resolve()
+    Pkg.instantiate()
+end
+
 using Documenter
 using MPSKitModels
 
@@ -13,6 +22,7 @@ makedocs(;
                              "man/mpoham.md",
                              "man/lattices.md",
                              "man/models.md"],
-                "Index" => "package_index.md"])
+                "Index" => "package_index.md"],
+         checkdocs=:public)
 
 deploydocs(; repo="github.com/QuantumKitHub/MPSKitModels.jl.git")

--- a/docs/src/man/lattices.md
+++ b/docs/src/man/lattices.md
@@ -10,6 +10,8 @@ In order to facilitate this mapping, the combination of the `@mpoham` macro and 
 ```@docs
 AbstractLattice
 FiniteChain
+FiniteCylinder
+FiniteStrip
 InfiniteChain
 InfiniteCylinder
 InfiniteHelix
@@ -26,6 +28,7 @@ LatticePoint
 linearize_index
 vertices
 nearest_neighbours
+next_nearest_neighbours
 bipartition
 ```
 

--- a/docs/src/man/models.md
+++ b/docs/src/man/models.md
@@ -9,10 +9,12 @@ CurrentModule = MPSKitModels
 ```@docs
 transverse_field_ising
 kitaev_model
+quantum_potts
 heisenberg_XXX
 heisenberg_XXZ
 heisenberg_XYZ
 bilinear_biquadratic_model
+tj_model
 hubbard_model
 bose_hubbard_model
 quantum_chemistry_hamiltonian

--- a/docs/src/man/mpoham.md
+++ b/docs/src/man/mpoham.md
@@ -1,7 +1,7 @@
 # The `@mpoham` macro
 
 ```@meta
-CurrentModule = TensorKit
+CurrentModule = MPSKitModels
 ```
 
 When dealing with (quasi-) one-dimensional systems that are defined by a sum of local operators, a convenient representation exists in terms of a sparse matrix product operator with an upper diagonal structure (`MPOHamiltonian`).
@@ -9,4 +9,11 @@ The generation of such an object starting from a sum of local operators is facil
  
 ```@docs
 @mpoham
+```
+
+Internally, the macro generates operators that have some knowledge of the lattice structure, through the following structures:
+
+```@docs
+LocalOperator
+SumOfLocalOperators
 ```

--- a/docs/src/man/operators.md
+++ b/docs/src/man/operators.md
@@ -34,6 +34,7 @@ S_zz
 S_plusmin
 S_minplus
 S_exchange
+spinmatrices
 ```
 
 For convenience, the Pauli matrices can also be recovered as ``σⁱ = 2 Sⁱ``.
@@ -62,6 +63,8 @@ Supported values of `symmetry` for the `X` operator are `Trivial` and `ZNIrrep{Q
 potts_X
 potts_Z
 potts_ZZ
+potts_field
+weyl_heisenberg_matrices
 ```
 
 ## Bosonic operators
@@ -102,8 +105,12 @@ c_number
 
 Spinful fermions.
 
-```@docs
-e_plus
-e_min
-e_number
+```@autodocs
+Modules = [MPSKitModels.HubbardOperators]
+```
+
+TJ-model operators.
+
+```@autodocs
+Modules = [MPSKitModels.TJOperators]
 ```

--- a/src/models/hamiltonians.jl
+++ b/src/models/hamiltonians.jl
@@ -371,7 +371,7 @@ function bose_hubbard_model(elt::Type{<:Number}=ComplexF64,
     elseif symmetry === U1Irrep
         isinteger(2n) ||
             throw(ArgumentError("`U₁` symmetry requires halfinteger particle number"))
-        H = MPSKit.add_physical_charge(H, fill(U1Irrep(-n), length(H)))
+        H = MPSKit.add_physical_charge(H, fill(U1Irrep(n), length(H)))
     else
         throw(ArgumentError("symmetry not implemented"))
     end

--- a/src/operators/spinoperators.jl
+++ b/src/operators/spinoperators.jl
@@ -470,15 +470,6 @@ function potts_ZZ(elt::Type{<:Number}, ::Type{ZNIrrep{Q}}; q=Q) where {Q}
 end
 
 """
-    potts_field([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; q=3) 
-
-The Potts field operator ``X``, an alias for ``potts_X``.
-"""
-potts_field(args...; kwargs...) = potts_X(args...; kwargs...)
-
-# Generalisations of Pauli matrices
-
-"""
     weyl_heisenberg_matrices(dimension [, eltype])
 
 the Weyl-Heisenberg matrices according to [Wikipedia](https://en.wikipedia.org/wiki/Generalizations_of_Pauli_matrices#Sylvester's_generalized_Pauli_matrices_(non-Hermitian)).
@@ -516,6 +507,7 @@ end
 
 """
     potts_X([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; Q=3)
+    potts_field([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; Q=3)
 
 The Potts X operator, also known as the shift operator, where X^q=1.
 """
@@ -539,3 +531,5 @@ function potts_X(elt::Type{<:Number}, ::Type{ZNIrrep{Q}}; q=Q) where {Q}
     end
     return X
 end
+
+const potts_field = potts_X


### PR DESCRIPTION
Adjust the charge shift convention in the Bose Hubbard Hamiltonian, update compatibility with MPSKit v0.13, and make `potts_field` an alias for `potts_X`. Additionally, update the Documenter version to v1.